### PR TITLE
Migrate to use v0.14 API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.3.1
+  - 2.3.5
+  - 2.4.2
 before_install: gem install bundler -v 1.13.5

--- a/fluent-plugin-genhashvalue.gemspec
+++ b/fluent-plugin-genhashvalue.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.13"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_runtime_dependency "fluentd", "~> 0.12"
+  spec.add_runtime_dependency "fluentd", [">= 0.14.0", "< 2"]
   spec.add_runtime_dependency "base91", '>= 0.0.1'
 end

--- a/lib/fluent/plugin/filter_genhashvalue.rb
+++ b/lib/fluent/plugin/filter_genhashvalue.rb
@@ -1,6 +1,6 @@
-require 'fluent/filter'
+require 'fluent/plugin/filter'
 
-module Fluent
+module Fluent::Plugin
   class GenHashValueFilter < Filter
     Fluent::Plugin.register_filter('genhashvalue', self)
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -12,6 +12,8 @@ require 'test/unit'
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'fluent/test'
+require 'fluent/test/helpers'
+require 'fluent/test/driver/filter'
 unless ENV.has_key?('VERBOSE')
   nulllogger = Object.new
   nulllogger.instance_eval {|obj|
@@ -25,5 +27,5 @@ end
 require 'fluent/plugin/filter_genhashvalue'
 
 class Test::Unit::TestCase
+  include Fluent::Test::Helpers
 end
-

--- a/test/plugin/test_out_genuniqueid.rb
+++ b/test/plugin/test_out_genuniqueid.rb
@@ -6,8 +6,8 @@ class GenHashValueFilterTest < Test::Unit::TestCase
     Fluent::Test.setup
   end
 
-  def create_driver(conf = CONFIG, tag='test')
-    Fluent::Test::FilterTestDriver.new(Fluent::GenHashValueFilter, tag).configure(conf)
+  def create_driver(conf = CONFIG)
+    Fluent::Test::Driver::Filter.new(Fluent::Plugin::GenHashValueFilter).configure(conf)
   end
 
   def test_configure
@@ -39,184 +39,140 @@ class GenHashValueFilterTest < Test::Unit::TestCase
     assert_equal ['id2'], d.instance.keys
   end
 
-
-  def test_md5
+  data("base" => {"base64_enc" => false,
+                  "base91_enc" => false,
+                  "expected" => "94666f1c6ecde15a182a8a165bd9c2a0"},
+       "base64_enc" => {"base64_enc" => true,
+                        "base91_enc" => false,
+                        "expected" => "lGZvHG7N4VoYKooWW9nCoA=="},
+       "base91_enc" => {"base64_enc" => false,
+                        "base91_enc" => true,
+                        "expected" => "VT.Jo=nV~PT7k<Cg=K`T"}
+       )
+  def test_md5(data)
     d = create_driver(%[
       keys id, time, v, k
       hash_type md5 # md5 or sha1 or sha256 or sha512
-      base64_enc false
+      base64_enc "#{data["base64_enc"]}"
+      base91_enc "#{data["base91_enc"]}"
       set_key _id
       separator ,
       inc_time_as_key false
       inc_tag_as_key false
     ])
-    time = Time.parse("2011-01-02 13:14:15 UTC").to_i
-    time2 = Time.now.to_i
+    time = event_time("2011-01-02 13:14:15 UTC")
+    time2 = event_time
 
-    d.run do
-      d.emit({"id"=>1, "time"=>time, "v"=>"日本語", "k"=>"値"}, time)
-      d.emit({"id"=>1, "time"=>time, "v"=>"日本語", "k"=>"値"}, time)
+    d.run(default_tag: 'test', shutdown: false) do
+      d.feed(time, {"id"=>1, "time"=>time, "v"=>"日本語", "k"=>"値"})
+      d.feed(time, {"id"=>1, "time"=>time, "v"=>"日本語", "k"=>"値"})
     end
 
     # ### FileOutput#write returns path
-    filtered = d.filtered_as_array
-    assert_equal 1, filtered[0][2]['id']
-    assert_equal "94666f1c6ecde15a182a8a165bd9c2a0", filtered[0][2]['_id']
-
-    d.instance.base64_enc = true
-
-    d.run do
-      d.emit({"id"=>1, "time"=>time, "v"=>"日本語", "k"=>"値"}, time)
-    end
-    filtered = d.filtered_as_array
-    assert_equal 1, filtered[0][2]['id']
-    assert_equal "lGZvHG7N4VoYKooWW9nCoA==", filtered[0][2]['_id']
-
-    d.instance.base64_enc = false
-    d.instance.base91_enc = true
-
-    d.run do
-      d.emit({"id"=>1, "time"=>time, "v"=>"日本語", "k"=>"値"}, time)
-    end
-    filtered = d.filtered_as_array
-    assert_equal 1, filtered[0][2]['id']
-    assert_equal "VT.Jo=nV~PT7k<Cg=K`T", filtered[0][2]['_id']
+    filtered = d.filtered
+    assert_equal 1, filtered[0][1]['id']
+    assert_equal data["expected"], filtered[0][1]['_id']
   end
 
-  def test_sha1
+  data("base" => {"base64_enc" => false,
+                  "base91_enc" => false,
+                  "expected" => "04b34892838c50d7e05b2d7ac471485e02323282"},
+       "base64_enc" => {"base64_enc" => true,
+                        "base91_enc" => false,
+                        "expected" => "BLNIkoOMUNfgWy16xHFIXgIyMoI="},
+       "base91_enc" => {"base64_enc" => false,
+                        "base91_enc" => true,
+                        "expected" => "t1mz#vxE?]UntYN+)Xb1PjgMM"}
+       )
+  def test_sha1(data)
     d = create_driver(%[
       keys id, time, v, k
       hash_type sha1 # md5 or sha1 or sha256 or sha512
-      base64_enc false
+      base64_enc "#{data["base64_enc"]}"
+      base91_enc "#{data["base91_enc"]}"
       set_key _id
       separator ,
       inc_time_as_key false
       inc_tag_as_key false
     ])
-    time = Time.parse("2011-01-02 13:14:15 UTC").to_i
-    time2 = Time.now.to_i
+    time = event_time("2011-01-02 13:14:15 UTC")
+    time2 = event_time
 
-    d.run do
-      d.emit({"id"=>1, "time"=>time, "v"=>"日本語", "k"=>"値"}, time)
+    d.run(default_tag: 'test') do
+      d.feed(time, {"id"=>1, "time"=>time, "v"=>"日本語", "k"=>"値"})
     end
 
     # ### FileOutput#write returns path
-    filtered = d.filtered_as_array
-    assert_equal 1, filtered[0][2]['id']
-    assert_equal "04b34892838c50d7e05b2d7ac471485e02323282", filtered[0][2]['_id']
-
-    d.instance.base64_enc = true
-
-    d.run do
-      d.emit({"id"=>1, "time"=>time, "v"=>"日本語", "k"=>"値"}, time)
-    end
-    filtered = d.filtered_as_array
-    assert_equal 1, filtered[0][2]['id']
-    assert_equal "BLNIkoOMUNfgWy16xHFIXgIyMoI=", filtered[0][2]['_id']
-
-    d.instance.base64_enc = false
-    d.instance.base91_enc = true
-
-    d.run do
-      d.emit({"id"=>1, "time"=>time, "v"=>"日本語", "k"=>"値"}, time)
-    end
-    filtered = d.filtered_as_array
-    assert_equal 1, filtered[0][2]['id']
-    assert_equal "t1mz#vxE?]UntYN+)Xb1PjgMM", filtered[0][2]['_id']
+    filtered = d.filtered
+    assert_equal 1, filtered[0][1]['id']
+    assert_equal data["expected"], filtered[0][1]['_id']
   end
 
-  def test_sha256
+  data("base" => {"base64_enc" => false,
+                  "base91_enc" => false,
+                  "expected" => "faf53c1c9cc89e896b812f90ac77ad04447faece9eff6cbf62975c618c5ffb1f"},
+       "base64_enc" => {"base64_enc" => true,
+                        "base91_enc" => false,
+                        "expected" => "+vU8HJzInolrgS+QrHetBER/rs6e/2y/YpdcYYxf+x8="},
+       "base91_enc" => {"base64_enc" => false,
+                        "base91_enc" => true,
+                        "expected" => "q(gFR&W^=@/E3Y~^urp\"|~B\"B\"B\"B\"B\"B\"B\"B\"B\"\"\""}
+       )
+  def test_sha256(data)
     d = create_driver(%[
       keys id, time, v, k
       hash_type sha256 # md5 or sha1 or sha256 or sha512
-      base64_enc false
+      base64_enc "#{data["base64_enc"]}"
+      base91_enc "#{data["base91_enc"]}"
       set_key _id
       separator ,
       inc_time_as_key false
       inc_tag_as_key false
     ])
-    time = Time.parse("2016-10-23 13:14:15 UTC").to_i
-    time2 = Time.now.to_i
+    time = event_time("2016-10-23 13:14:15 UTC")
+    time2 = event_time
 
-    d.run do
-      d.emit({"id"=>1, "time"=>time, "time2"=>time2, "v"=>"日本語", "k"=>"値"}, time)
+    d.run(default_tag: 'test') do
+      d.feed(time, {"id"=>1, "time"=>time, "time2"=>time2, "v"=>"日本語", "k"=>"値"})
     end
 
     # ### FileOutput#write returns path
-    filtered = d.filtered_as_array
-    assert_equal 1, filtered[0][2]['id']
-    assert_equal "faf53c1c9cc89e896b812f90ac77ad04447faece9eff6cbf62975c618c5ffb1f", filtered[0][2]['_id']
-
-    d.instance.base64_enc = true
-
-    d.run do
-      d.emit({"id"=>1, "time"=>time, "v"=>"日本語", "k"=>"値"}, time)
-    end
-    filtered = d.filtered_as_array
-    assert_equal 1, filtered[0][2]['id']
-    assert_equal "+vU8HJzInolrgS+QrHetBER/rs6e/2y/YpdcYYxf+x8=", filtered[0][2]['_id']
-
-    d.instance.base64_enc = false
-    d.instance.base91_enc = true
-
-    d.run do
-      d.emit({"id"=>1, "time"=>time, "v"=>"日本語", "k"=>"値"}, time)
-    end
-    filtered = d.filtered_as_array
-    assert_equal 1, filtered[0][2]['id']
-    assert_equal "q(gFR&W^=@/E3Y~^urp\"|~B\"B\"B\"B\"B\"B\"B\"B\"B\"\"\"", filtered[0][2]['_id']
+    filtered = d.filtered
+    assert_equal 1, filtered[0][1]['id']
+    assert_equal data["expected"], filtered[0][1]['_id']
   end
 
-  def test_sha512
+  data("base" => {"base64_enc" => false,
+                  "base91_enc" => false,
+                  "expected" =>"a9188951cec474bf5a0704f3fefc00f9e903d0190c7daed5cca1a190346d508da640a939b25b2455d0acdd2ad6c49c218ac31e3fb6a70c7ae2838e4cfab955fc"},
+       "base64_enc" => {"base64_enc" => true,
+                        "base91_enc" => false,
+                        "expected" => "qRiJUc7EdL9aBwTz/vwA+ekD0BkMfa7VzKGhkDRtUI2mQKk5slskVdCs3SrWxJwhisMeP7anDHrig45M+rlV/A=="},
+       "base91_enc" => {"base64_enc" => false,
+                        "base91_enc" => true,
+                        "expected" => "J+go,3[a^sfK`hA\"/C1~)CZ3Mvj%X}J@M1Nbz4cmm4q[ks,Mj2u}NeKsQ_WOL<RWkWNu|*G^u6h_x]f"}
+       )
+  def test_sha512(data)
     d = create_driver(%[
       keys id, time, v, k
       hash_type sha512 # md5 or sha1 or sha256 or sha512
-      base64_enc false
+      base64_enc "#{data["base64_enc"]}"
+      base91_enc "#{data["base91_enc"]}"
       set_key _id
       separator ,
       inc_time_as_key false
       inc_tag_as_key false
     ])
-    time = Time.parse("2016-10-23 13:14:15 UTC").to_i
-    time2 = Time.now.to_i
+    time = event_time("2016-10-23 13:14:15 UTC")
+    time2 = event_time
 
-    d.run do
-      d.emit({"id"=>1, "time"=>time, "time2"=>time2, "v"=>"日本語", "k"=>"値"}, time)
+    d.run(default_tag: 'test') do
+      d.feed(time, {"id"=>1, "time"=>time, "time2"=>time2, "v"=>"日本語", "k"=>"値"})
     end
 
     # ### FileOutput#write returns path
-    filtered = d.filtered_as_array
-    assert_equal 1, filtered[0][2]['id']
-    assert_equal "a9188951cec474bf5a0704f3fefc00f9e903d0190c7daed5cca1a190346d508da640a939b25b2455d0acdd2ad6c49c218ac31e3fb6a70c7ae2838e4cfab955fc",
-                 filtered[0][2]['_id']
-
-    d.instance.base64_enc = true
-
-    d.run do
-      d.emit({"id"=>1, "time"=>time, "v"=>"日本語", "k"=>"値"}, time)
-    end
-    filtered = d.filtered_as_array
-    assert_equal 1, filtered[0][2]['id']
-    assert_equal "qRiJUc7EdL9aBwTz/vwA+ekD0BkMfa7VzKGhkDRtUI2mQKk5slskVdCs3SrWxJwhisMeP7anDHrig45M+rlV/A==", filtered[0][2]['_id']
-
-    d.instance.keys = ['time2']
-    d.instance.base64_enc = false
-    d.run do
-      d.emit({"id"=>1, "time"=>time, "time2"=>time2, "v"=>"日本語", "k"=>"値"}, time)
-    end
-    filtered = d.filtered_as_array
-    assert_equal Digest::SHA512::hexdigest(time2.to_s), filtered[0][2]['_id']
-
-    d.instance.base64_enc = false
-    d.instance.base91_enc = true
-    d.instance.keys = ['id', 'time', 'v', 'k']
-
-    d.run do
-      d.emit({"id"=>1, "time"=>time, "v"=>"日本語", "k"=>"値"}, time)
-    end
-    filtered = d.filtered_as_array
-    assert_equal 1, filtered[0][2]['id']
-    assert_equal "J+go,3[a^sfK`hA\"/C1~)CZ3Mvj%X}J@M1Nbz4cmm4q[ks,Mj2u}NeKsQ_WOL<RWkWNu|*G^u6h_x]f", filtered[0][2]['_id']
-
+    filtered = d.filtered
+    assert_equal 1, filtered[0][1]['id']
+    assert_equal data["expected"], filtered[0][1]['_id']
   end
 end


### PR DESCRIPTION
I've tried to migrate to use v0.14 Filter Plugin API.
This PR contains major update change and also includes in breaking changes.
If above questions/problems are acceptable or reasonable for you, could you bump up major version if releasing new version of gem?
And please refer http://docs.fluentd.org/v0.14/articles/plugin-update-from-v12 before release new version.

Thanks.